### PR TITLE
Pass observed data after references.

### DIFF
--- a/gap_statistic/optimalK.py
+++ b/gap_statistic/optimalK.py
@@ -276,7 +276,7 @@ class OptimalK:
 
         # Fit cluster to original data and create dispersion calc.
         centroids, labels = self.clusterer(
-            random_data, n_clusters, **self.clusterer_kwargs
+            X, n_clusters, **self.clusterer_kwargs
         )  # type: Tuple[np.ndarray, np.ndarray]
         dispersion = self._calculate_dispersion(X=X, labels=labels, centroids=centroids)
 


### PR DESCRIPTION
Will close #33 

The null dataset was being returned for the final
gap calculations rather than the observed. The Rust
implementation was confirmed to be doing this correctly
so no fix was needed there.