### PR TITLE
Return the standard errors of the Gap statistic

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The columns of the dataframe are:
   - `gap_value` - The Gap value for this `n`.
   - `gap*` - The Gap\* value for this `n`.
   - `ref_dispersion_std` - The standard deviation of the reference distributions for this `n`.
+  - `sk` - The standard error of the Gap statistic for this `n`.
+  - `sk*` - The standard error of the Gap\* statistic for this `n`.
   - `diff` - The diff value for this `n` (see the methodology section for details).
   - `diff*` - The diff\* value for this `n` (corresponding to the diff value for Gap\*).
 

--- a/gap_statistic/optimalK.py
+++ b/gap_statistic/optimalK.py
@@ -152,7 +152,7 @@ class OptimalK:
 
         # drop auxilariy columns
         gap_df.drop(
-            labels=["sdk", "sk", "sk*", "gap_k+1", "gap*_k+1", "sk+1", "sk*+1"],
+            labels=["sdk", "gap_k+1", "gap*_k+1", "sk+1", "sk*+1"],
             axis=1,
             inplace=True,
             errors="ignore",


### PR DESCRIPTION
This patch preserves the standard errors in the resulting DataFrame, allowing to:

- plot the error bars around the Gap statistic; 
- manually recompute the original criterion for the optimal number of clusters according to Tibshirani et al. Though this can already be done based on the `diff` column.

Addresses the comments in #18. Let me know if any changes to the PR are necessary. I'd be happy to work on it.