### PR TITLE
Generate reference datasets uniformly over the range of each feature

### DIFF
--- a/gap_statistic/optimalK.py
+++ b/gap_statistic/optimalK.py
@@ -259,11 +259,15 @@ class OptimalK:
         # Holder for reference dispersion results
         ref_dispersions = np.zeros(n_refs)
 
+        # Compute the range of each feature
+        X = np.asarray(X)
+        a, b = X.min(axis=0, keepdims=True), X.max(axis=0, keepdims=True)
+
         # For n_references, generate random sample and perform kmeans getting resulting dispersion of each loop
         for i in range(n_refs):
 
-            # Create new random reference set
-            random_data = np.random.random_sample(size=X.shape)
+            # Create new random reference set uniformly over the range of each feature
+            random_data = np.random.random_sample(size=X.shape) * (b - a) + a
 
             # Fit to it, getting the centroids and labels, and add to accumulated reference dispersions array.
             centroids, labels = self.clusterer(


### PR DESCRIPTION
This patch brings the reference datasets in line with Tibshirani et al., option (a):
"Generate each reference feature uniformly over the range of the observed values for that feature".

Fixes #38.

All of the non-Rust tests succeed on my machine. I've also compared the resulting values of the gap statistic and the associated standard errors to the output of `cluster::clusGap()` in R on a simple example. The values are very similar under certain conditions required to reduce the variability. For instance, I increased the number of reference distributions (`n_refs=100`) and used a custom scikit-learn clusterer with multiple automatic restarts, i.e. `KMeans(n_init=50)`.

Let me know if any changes to the code or additional tests are necessary. Thanks!